### PR TITLE
Version that works with more than 5 chained chips.

### DIFF
--- a/Adafruit_TLC5947.cpp
+++ b/Adafruit_TLC5947.cpp
@@ -16,28 +16,26 @@
  ****************************************************/
 #include <Adafruit_TLC5947.h>
 
-Adafruit_TLC5947::Adafruit_TLC5947(uint32_t n, uint32_t c, uint32_t d, uint32_t l, uint32_t b) {
-  numdrivers = n;
+Adafruit_TLC5947::Adafruit_TLC5947(uint8_t n, uint8_t c, uint8_t d, uint8_t l, uint8_t b) {
+  num = n;
   _clk = c;
   _dat = d;
   _lat = l;
   _blk = b;
-  pwmbuffer = (uint32_t *)calloc(24*n, sizeof(uint32_t));
+  pwmbuffer = (uint16_t *)calloc(24*n, sizeof(uint16_t));
 }
 
 void Adafruit_TLC5947::write(void) {
   digitalWrite(_blk, HIGH);
   digitalWrite(_lat, LOW);
   digitalWrite(_blk, LOW);
-  for (int32_t c=24*numdrivers - 1; c >= 0 ; c--) {
-    for (int32_t b=11; b>=0; b--) {
+  for (int16_t c=24*num - 1; c >= 0 ; c--) {
+    for (int8_t b=11; b>=0; b--) {
       digitalWrite(_clk, LOW);
       if (pwmbuffer[c] & (1 << b))   {
         digitalWrite(_dat, HIGH);
-        //Serial.println(1);
       } else {
         digitalWrite(_dat, LOW);
-        //Serial.println(0);
        }
       digitalWrite(_clk, HIGH);
     }
@@ -47,13 +45,13 @@ void Adafruit_TLC5947::write(void) {
   digitalWrite(_lat, LOW);
 }
 
-void Adafruit_TLC5947::setPWM(uint32_t chan, uint32_t pwm) {
+void Adafruit_TLC5947::setPWM(uint16_t chan, uint16_t pwm) {
   if (pwm > 4095) pwm = 4095;
-  if (chan > 24*numdrivers) return;
+  if (chan > 24*num) return;
   pwmbuffer[chan] = pwm;  
 }
 
-void Adafruit_TLC5947::setLED(uint32_t lednum, uint32_t b, uint32_t r, uint32_t g) {
+void Adafruit_TLC5947::setLED(uint16_t lednum, uint16_t b, uint16_t r, uint16_t g) {
   setPWM(lednum*3, b);
   setPWM(lednum*3+1, r);
   setPWM(lednum*3+2, g);
@@ -66,12 +64,4 @@ boolean Adafruit_TLC5947::begin() {
   pinMode(_lat, OUTPUT);
   pinMode(_blk, OUTPUT);
   return true;
-}
-
-void Adafruit_TLC5947::print() {
-	for(int i = 0;i < 192;++i) {
-		Serial.println(pwmbuffer[i]);
-		Serial.println(' ');
-	}
-	Serial.println("END");
 }

--- a/Adafruit_TLC5947.cpp
+++ b/Adafruit_TLC5947.cpp
@@ -16,7 +16,7 @@
  ****************************************************/
 #include <Adafruit_TLC5947.h>
 
-Adafruit_TLC5947::Adafruit_TLC5947(const uint8_t& n, const uint8_t& c, const uint8_t& d, const uint8_t& l, const uint8_t& b) {
+Adafruit_TLC5947::Adafruit_TLC5947(const uint8_t& n, const uint8_t& c, const uint8_t& d, const uint8_t& l, const uint8_t& b = -1) {
   num = n;
   _clk = c;
   _dat = d;
@@ -30,9 +30,9 @@ Adafruit_TLC5947::~Adafruit_TLC5947(void) {
 }
 
 void Adafruit_TLC5947::write(void) {
-  digitalWrite(_blk, HIGH);
+  if(_blk > -1)
+    digitalWrite(_blk, LOW);
   digitalWrite(_lat, LOW);
-  digitalWrite(_blk, LOW);
   for (int16_t c = 24*num - 1;c >= 0;--c) {
     for (int8_t b=11; b>=0; b--) {
       digitalWrite(_clk, LOW);
@@ -62,6 +62,9 @@ boolean Adafruit_TLC5947::begin() {
   pinMode(_clk, OUTPUT);
   pinMode(_dat, OUTPUT);
   pinMode(_lat, OUTPUT);
-  pinMode(_blk, OUTPUT);
+  if(_blk > -1) {
+    pinMode(_blk, OUTPUT);
+    digitalWrite(_blk, HIGH);
+  }
   return true;
 }

--- a/Adafruit_TLC5947.cpp
+++ b/Adafruit_TLC5947.cpp
@@ -16,7 +16,7 @@
  ****************************************************/
 #include <Adafruit_TLC5947.h>
 
-Adafruit_TLC5947::Adafruit_TLC5947(uint8_t n, uint8_t c, uint8_t d, uint8_t l, uint8_t b) {
+Adafruit_TLC5947::Adafruit_TLC5947(const uint8_t& n, const uint8_t& c, const uint8_t& d, const uint8_t& l, const uint8_t& b) {
   num = n;
   _clk = c;
   _dat = d;
@@ -25,18 +25,18 @@ Adafruit_TLC5947::Adafruit_TLC5947(uint8_t n, uint8_t c, uint8_t d, uint8_t l, u
   pwmbuffer = (uint16_t *)calloc(24*n, sizeof(uint16_t));
 }
 
+Adafruit_TLC5947::~Adafruit_TLC5947(void) {
+  free(pwmbuffer);
+}
+
 void Adafruit_TLC5947::write(void) {
   digitalWrite(_blk, HIGH);
   digitalWrite(_lat, LOW);
   digitalWrite(_blk, LOW);
-  for (int16_t c=24*num - 1; c >= 0 ; c--) {
+  for (int16_t c = 24*num - 1;c >= 0;--c) {
     for (int8_t b=11; b>=0; b--) {
       digitalWrite(_clk, LOW);
-      if (pwmbuffer[c] & (1 << b))   {
-        digitalWrite(_dat, HIGH);
-      } else {
-        digitalWrite(_dat, LOW);
-       }
+      (pwmbuffer[c] & (1 << b)) ? digitalWrite(_dat, HIGH) : digitalWrite(_dat, LOW);
       digitalWrite(_clk, HIGH);
     }
   }
@@ -45,13 +45,13 @@ void Adafruit_TLC5947::write(void) {
   digitalWrite(_lat, LOW);
 }
 
-void Adafruit_TLC5947::setPWM(uint16_t chan, uint16_t pwm) {
+void Adafruit_TLC5947::setPWM(const uint8_t& chan, const uint8_t& pwm) {
   if (pwm > 4095) pwm = 4095;
   if (chan > 24*num) return;
   pwmbuffer[chan] = pwm;  
 }
 
-void Adafruit_TLC5947::setLED(uint16_t lednum, uint16_t b, uint16_t r, uint16_t g) {
+void Adafruit_TLC5947::setLED(const uint8_t& lednum, const uint8_t& b, const uint8_t& r, const uint8_t& g) {
   setPWM(lednum*3, b);
   setPWM(lednum*3+1, r);
   setPWM(lednum*3+2, g);

--- a/Adafruit_TLC5947.cpp
+++ b/Adafruit_TLC5947.cpp
@@ -14,64 +14,64 @@
   Written by Limor Fried/Ladyada for Adafruit Industries.  
   BSD license, all text above must be included in any redistribution
  ****************************************************/
-
-
 #include <Adafruit_TLC5947.h>
 
-Adafruit_TLC5947::Adafruit_TLC5947(uint8_t n, uint8_t c, uint8_t d, uint8_t l) {
+Adafruit_TLC5947::Adafruit_TLC5947(uint32_t n, uint32_t c, uint32_t d, uint32_t l, uint32_t b) {
   numdrivers = n;
   _clk = c;
   _dat = d;
   _lat = l;
-
-  pwmbuffer = (uint16_t *)calloc(2, 24*n);
+  _blk = b;
+  pwmbuffer = (uint32_t *)calloc(24*n, sizeof(uint32_t));
 }
 
 void Adafruit_TLC5947::write(void) {
+  digitalWrite(_blk, HIGH);
   digitalWrite(_lat, LOW);
-  // 24 channels per TLC5974
-  for (int8_t c=24*numdrivers - 1; c >= 0 ; c--) {
-    // 12 bits per channel, send MSB first
-    for (int8_t b=11; b>=0; b--) {
+  digitalWrite(_blk, LOW);
+  for (int32_t c=24*numdrivers - 1; c >= 0 ; c--) {
+    for (int32_t b=11; b>=0; b--) {
       digitalWrite(_clk, LOW);
-      
-      if (pwmbuffer[c] & (1 << b))  
+      if (pwmbuffer[c] & (1 << b))   {
         digitalWrite(_dat, HIGH);
-      else
+        //Serial.println(1);
+      } else {
         digitalWrite(_dat, LOW);
-
+        //Serial.println(0);
+       }
       digitalWrite(_clk, HIGH);
     }
   }
   digitalWrite(_clk, LOW);
-  
   digitalWrite(_lat, HIGH);  
   digitalWrite(_lat, LOW);
 }
 
-
-
-void Adafruit_TLC5947::setPWM(uint8_t chan, uint16_t pwm) {
+void Adafruit_TLC5947::setPWM(uint32_t chan, uint32_t pwm) {
   if (pwm > 4095) pwm = 4095;
   if (chan > 24*numdrivers) return;
   pwmbuffer[chan] = pwm;  
 }
 
-
-void Adafruit_TLC5947::setLED(uint8_t lednum, uint16_t r, uint16_t g, uint16_t b) {
-  setPWM(lednum*3, r);
-  setPWM(lednum*3+1, g);
-  setPWM(lednum*3+2, b);
+void Adafruit_TLC5947::setLED(uint32_t lednum, uint32_t b, uint32_t r, uint32_t g) {
+  setPWM(lednum*3, b);
+  setPWM(lednum*3+1, r);
+  setPWM(lednum*3+2, g);
 }
-
 
 boolean Adafruit_TLC5947::begin() {
   if (!pwmbuffer) return false;
-
   pinMode(_clk, OUTPUT);
   pinMode(_dat, OUTPUT);
   pinMode(_lat, OUTPUT);
-  digitalWrite(_lat, LOW);
-
+  pinMode(_blk, OUTPUT);
   return true;
+}
+
+void Adafruit_TLC5947::print() {
+	for(int i = 0;i < 192;++i) {
+		Serial.println(pwmbuffer[i]);
+		Serial.println(' ');
+	}
+	Serial.println("END");
 }

--- a/Adafruit_TLC5947.h
+++ b/Adafruit_TLC5947.h
@@ -14,30 +14,22 @@
   Written by Limor Fried/Ladyada for Adafruit Industries.  
   BSD license, all text above must be included in any redistribution
  ****************************************************/
-
 #ifndef _ADAFRUIT_TLC5947_H
 #define _ADAFRUIT_TLC5947_H
 
 #include <Arduino.h>
 
-
 class Adafruit_TLC5947 {
  public:
-  Adafruit_TLC5947(uint8_t n, uint8_t c, uint8_t d, uint8_t l);
-
+  Adafruit_TLC5947(uint32_t n, uint32_t c, uint32_t d, uint32_t l, uint32_t b);
   boolean begin(void);
-
-  void setPWM(uint8_t chan, uint16_t pwm);
-  void setLED(uint8_t lednum, uint16_t r, uint16_t g, uint16_t b);
+  void setPWM(uint32_t chan, uint32_t pwm);
+  void setLED(uint32_t lednum, uint32_t r, uint32_t g, uint32_t b);
   void write(void);
-
-
+  void print();
  private:
-  uint16_t *pwmbuffer;
-
-  uint8_t numdrivers, _clk, _dat, _lat;
-
+  uint32_t *pwmbuffer;
+  uint32_t numdrivers, _clk, _dat, _lat, _blk;
 };
-
 
 #endif

--- a/Adafruit_TLC5947.h
+++ b/Adafruit_TLC5947.h
@@ -21,10 +21,11 @@
 
 class Adafruit_TLC5947 {
  public:
-  Adafruit_TLC5947(uint8_t n, uint8_t c, uint8_t d, uint8_t l, uint8_t b);
+  Adafruit_TLC5947(const uint8_t& n, const uint8_t& c, const uint8_t& d, const uint8_t& l, const uint8_t& b);
+  ~Adafruit_TLC5947(void);
   boolean begin(void);
-  void setPWM(uint16_t chan, uint16_t pwm);
-  void setLED(uint16_t lednum, uint16_t b, uint16_t r, uint16_t g);
+  void setPWM(const uint8_t& chan, const uint8_t& pwm);
+  void setLED(const uint8_t& lednum, const uint8_t& b, const uint8_t& r, uint16_t g);
   void write(void);
  private:
   uint16_t *pwmbuffer;

--- a/Adafruit_TLC5947.h
+++ b/Adafruit_TLC5947.h
@@ -21,15 +21,14 @@
 
 class Adafruit_TLC5947 {
  public:
-  Adafruit_TLC5947(uint32_t n, uint32_t c, uint32_t d, uint32_t l, uint32_t b);
+  Adafruit_TLC5947(uint8_t n, uint8_t c, uint8_t d, uint8_t l, uint8_t b);
   boolean begin(void);
-  void setPWM(uint32_t chan, uint32_t pwm);
-  void setLED(uint32_t lednum, uint32_t r, uint32_t g, uint32_t b);
+  void setPWM(uint16_t chan, uint16_t pwm);
+  void setLED(uint16_t lednum, uint16_t b, uint16_t r, uint16_t g);
   void write(void);
-  void print();
  private:
-  uint32_t *pwmbuffer;
-  uint32_t numdrivers, _clk, _dat, _lat, _blk;
+  uint16_t *pwmbuffer;
+  uint8_t num, _clk, _dat, _lat, _blk;
 };
 
 #endif


### PR DESCRIPTION
# Changes:

_C++_ changes like _const&_ type of the arguments in the methods and destructor _~Adafruit_TLC5947()_  added  .
# The call to calloc() is correct now.

**_BLANK**_ signal control added if is passed to the constructor as _const uint8_t& b_.

_c_ type changed to _int16_t_ so more than 5 chips can be manipulated.
# If merge is made I will add comments (comments only make a good writen code ugly in my opinion).

:)
