### PR TITLE
added method getPWM()

### DIFF
--- a/Adafruit_TLC5947.cpp
+++ b/Adafruit_TLC5947.cpp
@@ -101,8 +101,7 @@ void Adafruit_TLC5947::setPWM(uint16_t chan, uint16_t pwm) {
 uint16_t Adafruit_TLC5947::getPWM(uint16_t chan) {
   if (chan >= 24 * numdrivers) {
     return 0;
-  }
-  else {
+  } else {
     return pwmbuffer[chan];
   }
 }

--- a/Adafruit_TLC5947.cpp
+++ b/Adafruit_TLC5947.cpp
@@ -93,10 +93,12 @@ void Adafruit_TLC5947::setPWM(uint16_t chan, uint16_t pwm) {
 }
 
 /*!
- *    @brief  Get the PWM value for channel. Return 0 for invalid channels.
+ *    @brief  Get the PWM value for channel.
  *    @param  chan
  *            channel number ([0 - 23] on each board, so channel 2 for second
  * board will be 25)
+ *    @return PWM value ([0 - 4095]) for valid channels, 0 for non-existing
+ * channels.
  */
 uint16_t Adafruit_TLC5947::getPWM(uint16_t chan) {
   if (chan >= 24 * numdrivers) {

--- a/Adafruit_TLC5947.cpp
+++ b/Adafruit_TLC5947.cpp
@@ -93,6 +93,21 @@ void Adafruit_TLC5947::setPWM(uint16_t chan, uint16_t pwm) {
 }
 
 /*!
+ *    @brief  Get the PWM value for channel. Return 0 for invalid channels.
+ *    @param  chan
+ *            channel number ([0 - 23] on each board, so channel 2 for second
+ * board will be 25)
+ */
+uint16_t Adafruit_TLC5947::getPWM(uint16_t chan) {
+  if (chan >= 24 * numdrivers) {
+    return 0;
+  }
+  else {
+    return pwmbuffer[chan];
+  }
+}
+
+/*!
  *    @brief  Set LED
  *    @param  lednum
  *            led number

--- a/Adafruit_TLC5947.h
+++ b/Adafruit_TLC5947.h
@@ -34,6 +34,7 @@ public:
   boolean begin(void);
 
   void setPWM(uint16_t chan, uint16_t pwm);
+  uint16_t getPWM(uint16_t chan);
   void setLED(uint16_t lednum, uint16_t r, uint16_t g, uint16_t b);
   void write();
 


### PR DESCRIPTION
Thank you for this great library!!

I added a method getPWM() to be able to access the current PWM values in private array pwmbuffer.

In a recent project I needed to calculate the **new** PWM value from the **current** PWM value. Instead of doing separate book-keeping in my sketch, I modified the library to be able to access the current PWM values which have to be stored anyways.

Drawback: The method only returns the PWM value stored in the private array variable pwmbuffer, whether the values have already been clocked out to the chip or not. There is no way to retrieve the current PWM values back from the TLC5947, because it is basically only a "stupid" shift register.

This commit should not break any existing code out there, as it just adds new functionality. The method works as intended (tested in my project). However, no test routines are added in this commit. Note: There are no test routines for setPWM() either... :smile:
