### PR TITLE
fixed off-by-1-bug in method setPWM()

### DIFF
--- a/Adafruit_TLC5947.cpp
+++ b/Adafruit_TLC5947.cpp
@@ -79,7 +79,7 @@ void Adafruit_TLC5947::write() {
 /*!
  *    @brief  Set the PWM channel / value
  *    @param  chan
- *            channel number ([0 - 23] on each board, so chanel 2 for second
+ *            channel number ([0 - 23] on each board, so channel 2 for second
  * board will be 25)
  *    @param  pwm
  *            pwm value [0-4095]
@@ -87,7 +87,7 @@ void Adafruit_TLC5947::write() {
 void Adafruit_TLC5947::setPWM(uint16_t chan, uint16_t pwm) {
   if (pwm > 4095)
     pwm = 4095;
-  if (chan > 24 * numdrivers)
+  if (chan >= 24 * numdrivers)
     return;
   pwmbuffer[chan] = pwm;
 }


### PR DESCRIPTION
Fixed a bug in setPWM() which could lead to an array-out-of-bounds write.

Example: With numdrivers == 1, the function call 'obj.setPWM(24, 1234)' would try to write to pwmbuffer[24] which is the 25th element of the array, outside the allocated memory area.

This should not impact existing code out there. If it does, the code itself was/is buggy and probably not running stable (writing to the 25th element of a 24-element-array may/will lead to memory corruption...?).

Also corrected a typo in the comment.
