### PR TITLE
Add destructor with `free`

### DIFF
--- a/Adafruit_TLC5947.cpp
+++ b/Adafruit_TLC5947.cpp
@@ -55,9 +55,7 @@ Adafruit_TLC5947::Adafruit_TLC5947(uint16_t n, uint8_t c, uint8_t d,
  *    @brief  Releases allocated resources
  */
 
-Adafruit_TLC5947::~Adafruit_TLC5947() {
-	free(pwmbuffer);
-}
+Adafruit_TLC5947::~Adafruit_TLC5947() { free(pwmbuffer); }
 
 /*!
  *    @brief  Writes PWM data to the all connected TLC5947 boards

--- a/Adafruit_TLC5947.cpp
+++ b/Adafruit_TLC5947.cpp
@@ -52,6 +52,14 @@ Adafruit_TLC5947::Adafruit_TLC5947(uint16_t n, uint8_t c, uint8_t d,
 }
 
 /*!
+ *    @brief  Releases allocated resources
+ */
+
+Adafruit_TLC5947::~Adafruit_TLC5947() {
+	free(pwmbuffer);
+}
+
+/*!
  *    @brief  Writes PWM data to the all connected TLC5947 boards
  */
 void Adafruit_TLC5947::write() {

--- a/Adafruit_TLC5947.h
+++ b/Adafruit_TLC5947.h
@@ -30,6 +30,7 @@
 class Adafruit_TLC5947 {
 public:
   Adafruit_TLC5947(uint16_t n, uint8_t c, uint8_t d, uint8_t l);
+  ~Adafruit_TLC5947();
 
   boolean begin(void);
 


### PR DESCRIPTION
Fixes https://github.com/adafruit/Adafruit_TLC5947/issues/10 by adding a destructor that frees allocated memory.

Prevents leaks when the object is not global, but created and destroyed several times during app run.